### PR TITLE
Adding Cassandra support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 tests:
 	@echo "Launching Tests in Docker Compose"
+	docker-compose -f dev-compose.yml up -d cassandra-primary cassandra
+	sleep 15
 	docker-compose -f dev-compose.yml up --build tests
 
 clean:

--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/julienschmidt/httprouter"
 	"github.com/madflojo/hord"
+	"github.com/madflojo/hord/drivers/cassandra"
 	"github.com/madflojo/hord/drivers/redis"
 	"github.com/madflojo/tarmac/callbacks"
 	"github.com/madflojo/tarmac/wasm"
@@ -117,12 +118,43 @@ func Run(c *viper.Viper) error {
 
 	// Setup the KV Connection
 	if cfg.GetBool("enable_kvstore") {
-		kv, err = redis.Dial(redis.Config{
-			Server:   cfg.GetString("kv_server"),
-			Password: cfg.GetString("kv_password"),
-		})
-		if err != nil {
-			return fmt.Errorf("could not establish kvstore connection - %s", err)
+		switch cfg.GetString("kvstore_type") {
+		case "redis":
+			kv, err = redis.Dial(redis.Config{
+				Server:   cfg.GetString("redis_server"),
+				Password: cfg.GetString("redis_password"),
+				SentinelConfig: redis.SentinelConfig{
+					Servers: cfg.GetStringSlice("redis_sentinel_servers"),
+					Master:  cfg.GetString("redis_sentinel_master"),
+				},
+				ConnectTimeout: time.Duration(cfg.GetInt("redis_connect_timeout")) * time.Second,
+				Database:       cfg.GetInt("redis_database"),
+				SkipTLSVerify:  cfg.GetBool("redis_hostname_verify"),
+				KeepAlive:      time.Duration(cfg.GetInt("redis_keepalive")) * time.Second,
+				MaxActive:      cfg.GetInt("redis_max_active"),
+				ReadTimeout:    time.Duration(cfg.GetInt("redis_read_timeout")) * time.Second,
+				WriteTimeout:   time.Duration(cfg.GetInt("redis_write_timeout")) * time.Second,
+			})
+			if err != nil {
+				return fmt.Errorf("could not establish kvstore connection - %s", err)
+			}
+		case "cassandra":
+			kv, err = cassandra.Dial(cassandra.Config{
+				Hosts:                      cfg.GetStringSlice("cassandra_hosts"),
+				Port:                       cfg.GetInt("cassandra_port"),
+				Keyspace:                   cfg.GetString("cassandra_keyspace"),
+				Consistency:                cfg.GetString("cassandra_consistency"),
+				ReplicationStrategy:        cfg.GetString("cassandra_repl_strategy"),
+				Replicas:                   cfg.GetInt("cassandra_replicas"),
+				User:                       cfg.GetString("cassandra_user"),
+				Password:                   cfg.GetString("cassandra_password"),
+				EnableHostnameVerification: cfg.GetBool("cassandra_hostname_verify"),
+			})
+			if err != nil {
+				return fmt.Errorf("could not establish kvstore connection - %s", err)
+			}
+		default:
+			return fmt.Errorf("unknown kvstore specified - %s", cfg.GetString("kvstore_type"))
 		}
 		defer kv.Close()
 
@@ -200,9 +232,11 @@ func Run(c *viper.Viper) error {
 	})
 
 	// Setup KVStore Callbacks
-	router.RegisterCallback("kvstore", "get", srv.kvStore.Get)
-	router.RegisterCallback("kvstore", "set", srv.kvStore.Set)
-	router.RegisterCallback("kvstore", "delete", srv.kvStore.Delete)
+	if cfg.GetBool("enable_kvstore") {
+		router.RegisterCallback("kvstore", "get", srv.kvStore.Get)
+		router.RegisterCallback("kvstore", "set", srv.kvStore.Set)
+		router.RegisterCallback("kvstore", "delete", srv.kvStore.Delete)
+	}
 
 	// Setup Logger Callbacks
 	router.RegisterCallback("logger", "info", srv.logger.Info)

--- a/app/app.go
+++ b/app/app.go
@@ -156,6 +156,8 @@ func Run(c *viper.Viper) error {
 		default:
 			return fmt.Errorf("unknown kvstore specified - %s", cfg.GetString("kvstore_type"))
 		}
+
+		// Clean up KV Store connections on shutdown
 		defer kv.Close()
 
 		// Initialize the KV
@@ -201,17 +203,7 @@ func Run(c *viper.Viper) error {
 		s := <-trap
 		log.Infof("Received shutdown signal %s", s)
 
-		// Shutdown the HTTP Server
-		err := srv.httpServer.Shutdown(context.Background())
-		if err != nil {
-			log.Errorf("Received errors when shutting down HTTP sessions %s", err)
-		}
-
-		// Close KV Sessions
-		kv.Close()
-
-		// Shutdown the app via runCtx
-		runCancel()
+		defer Stop()
 	}()
 
 	// Register Health Check Handler used for Liveness checks

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -20,7 +20,8 @@ func TestBadConfigs(t *testing.T) {
 	v.Set("enable_tls", false)
 	v.Set("listen_addr", "pandasdonotbelonghere")
 	v.Set("disable_logging", true)
-	v.Set("kv_server", "redis:6379")
+	v.Set("kvstore_type", "redis")
+	v.Set("redis_server", "redis:6379")
 	cfgs["invalid listener address"] = v
 
 	// Invalid TLS config
@@ -28,7 +29,8 @@ func TestBadConfigs(t *testing.T) {
 	v.Set("enable_tls", true)
 	v.Set("listen_addr", "0.0.0.0:8443")
 	v.Set("disable_logging", true)
-	v.Set("kv_server", "redis:6379")
+	v.Set("kvstore_type", "redis")
+	v.Set("redis_server", "redis:6379")
 	v.Set("cert_file", "/tmp/doesntexist")
 	v.Set("key_file", "/tmp/doesntexist")
 	cfgs["invalid TLS Config"] = v
@@ -39,7 +41,8 @@ func TestBadConfigs(t *testing.T) {
 	v.Set("listen_addr", "0.0.0.0:8443")
 	v.Set("disable_logging", true)
 	v.Set("enable_kvstore", true)
-	v.Set("kv_server", "")
+	v.Set("kvstore_type", "redis")
+	v.Set("redis_server", "")
 	cfgs["invalid KV Address"] = v
 
 	// Invalid WASM path
@@ -75,7 +78,8 @@ func TestRunningServer(t *testing.T) {
 	cfg := viper.New()
 	cfg.Set("disable_logging", true)
 	cfg.Set("listen_addr", "localhost:9000")
-	cfg.Set("kv_server", "redis:6379")
+	cfg.Set("kvstore_type", "redis")
+	cfg.Set("redis_server", "redis:6379")
 	cfg.Set("enable_kvstore", true)
 	cfg.Set("config_watch_interval", 5)
 	cfg.Set("use_consul", false)
@@ -103,13 +107,6 @@ func TestRunningServer(t *testing.T) {
 		}
 	})
 
-	/*
-		t.Run("Check Scheduler is set", func(t *testing.T) {
-			if len(scheduler.Tasks()) == 0 {
-				t.Errorf("Expected scheduler to have at least one task")
-			}
-		})
-	*/
 }
 
 func TestRunningTLSServer(t *testing.T) {
@@ -131,7 +128,9 @@ func TestRunningTLSServer(t *testing.T) {
 	cfg.Set("enable_tls", true)
 	cfg.Set("cert_file", "/tmp/cert")
 	cfg.Set("key_file", "/tmp/key")
-	cfg.Set("kv_server", "redis:6379")
+	cfg.Set("kvstore_type", "cassandra")
+	cfg.Set("cassandra_hosts", []string{"cassandra-primary", "cassandra"})
+	cfg.Set("cassandra_keyspace", "tarmac")
 	cfg.Set("enable_kvstore", true)
 	cfg.Set("listen_addr", "localhost:9000")
 	cfg.Set("config_watch_interval", 1)

--- a/app/server.go
+++ b/app/server.go
@@ -37,10 +37,12 @@ func (s *server) Health(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 // probes or any checks that validate the service is ready to accept traffic.
 func (s *server) Ready(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// Check other stuff here like KV connectivity, health of dependent services, etc.
-	err := kv.HealthCheck()
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		return
+	if cfg.GetBool("enable_kvstore") {
+		err := kv.HealthCheck()
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -8,8 +8,6 @@ services:
     environment:
       - "APP_ENABLE_TLS=false"
       - "APP_LISTEN_ADDR=0.0.0.0:8080"
-      - "APP_DB_SERVER=redis:6379"
-      - "APP_ENABLE_DB=true"
       - "APP_USE_CONSUL=true"
       - "APP_CONSUL_ADDR=consul:8500"
       - "APP_CONSUL_KEYS_PREFIX=tarmac/config"
@@ -30,19 +28,45 @@ services:
       - "./testdata:/testdata"
     environment:
       - "APP_ENABLE_TLS=false"
-      - "APP_DB_SERVER=redis:6379"
       - "APP_CONSUL_ADDR=consul:8500"
       - "APP_CONSUL_KEYS_PREFIX=tarmac/config"
       - "CONSUL_HTTP_ADDR=consul:8500"
       - "CONSUL_HTTP_SSL=false"
     depends_on:
       - redis
+      - cassandra-primary
+      - cassandra
       - consul
       - consulator
   redis:
     image: bitnami/redis:latest
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+  cassandra-primary:
+    image: madflojo/cassandra:latest
+    command: /bin/bash -c "sleep 1 && /docker-entrypoint.sh cassandra -f"
+    environment:
+      - CASSANDRA_KEYSPACE=tarmac
+    expose:
+      - 7000
+      - 7001
+      - 7199
+      - 9042
+      - 9160
+  cassandra:
+    image: madflojo/cassandra:latest
+    command: /bin/bash -c "sleep 15 && /docker-entrypoint.sh cassandra -f"
+    environment:
+      - CASSANDRA_SEEDS=cassandra-primary
+      - CASSANDRA_KEYSPACE=tarmac
+    depends_on:
+      - cassandra-primary
+    expose:
+      - 7000
+      - 7001
+      - 7199
+      - 9042
+      - 9160
   consul:
     image: consul
     ports:

--- a/docs/running-tarmac/configuration.md
+++ b/docs/running-tarmac/configuration.md
@@ -10,26 +10,45 @@ When using Environment Variables, all configurations are prefixed with `APP_`. T
 
 | Environment Variable | Consul/JSON | Type | Description |
 | :--- | :--- | :--- | :--- |
-| `APP_ENABLE_TLS` | `enable_tls` | bool | Enable the HTTPS Listener \(default: `True`\) |
-| `APP_LISTEN_ADDR` | `listen_addr` | string | Define the HTTP/HTTPS Listener address \(default: `0.0.0.0:8443`\) |
-| `APP_CONFIG_WATCH_INTERVAL` | `config_watch_interval` | integer | Frequency in seconds which Consul configuration will be refreshed \(default: 15\) |
-| `APP_USE_CONSUL` | `use_consul` | bool | Enable Consul based configuration \(default: `False`\) |
-| `APP_CONSUL_ADDR` | `consul_addr` | string | Consul address \(i.e. `consul.example.com:8500`\) |
-| `APP_CONSUL_KEYS_PREFIX` | `consul_keys_prefix` | string | Key path for app specific consul configuration |
-|  | `from_consul` | bool | Indicator to reflect whether Consul config was loaded |
-| `APP_DEBUG` | `debug` | bool | Enable debug logging |
-| `APP_TRACE` | `trace` | bool | Enable trace logging |
-| `APP_DISABLE_LOGGING` | `disable_logging` | bool | Disable all logging |
-| `APP_ENABLE_KVSTORE` | `enable_kvstore` | bool | Enable the KV Store |
-| `APP_KV_SERVER` | `kv_server` | string | KV Store server address |
-| `APP_KV_PASSWORD` | `kv_password` | string | KV Store password |
-| `APP_CERT_FILE` | `cert_file` | string | Certificate File Path \(i.e. `/some/path/cert.crt`\) |
-| `APP_KEY_FILE` | `key_file` | string | Key File Path \(i.e. `/some/path/cert.key`\) |
-| `APP_WASM_FUNCTION` | `wasm_function` | string | Path and Filename of the WASM Function to execute \(Default: `/functions/tarmac.wasm`\) |
+| `APP_ENABLE_TLS` | `enable_tls` | `bool` | Enable the HTTPS Listener \(default: `True`\) |
+| `APP_LISTEN_ADDR` | `listen_addr` | `string` | Define the HTTP/HTTPS Listener address \(default: `0.0.0.0:8443`\) |
+| `APP_CONFIG_WATCH_INTERVAL` | `config_watch_interval` | `int` | Frequency in seconds which Consul configuration will be refreshed \(default: `15`\) |
+| `APP_USE_CONSUL` | `use_consul` | `bool` | Enable Consul based configuration \(default: `False`\) |
+| `APP_CONSUL_ADDR` | `consul_addr` | `string` | Consul address \(i.e. `consul.example.com:8500`\) |
+| `APP_CONSUL_KEYS_PREFIX` | `consul_keys_prefix` | `string` | Key path for app specific consul configuration |
+|  | `from_consul` | `bool` | Indicator to reflect whether Consul config was loaded |
+| `APP_DEBUG` | `debug` | `bool` | Enable debug logging |
+| `APP_TRACE` | `trace` | `bool` | Enable trace logging |
+| `APP_DISABLE_LOGGING` | `disable_logging` | `bool` | Disable all logging |
+| `APP_CERT_FILE` | `cert_file` | `string` | Certificate File Path \(i.e. `/some/path/cert.crt`\) |
+| `APP_KEY_FILE` | `key_file` | `string` | Key File Path \(i.e. `/some/path/cert.key`\) |
+| `APP_WASM_FUNCTION` | `wasm_function` | `string` | Path and Filename of the WASM Function to execute \(Default: `/functions/tarmac.wasm`\) |
+| `APP_ENABLE_KVSTORE` | `enable_kvstore` | `bool` | Enable the KV Store |
+| `APP_KVSTORE_TYPE` | `kvstore_type` | `string` | Select KV Store to use (Options: `redis`, `cassandra`)|
+| `APP_REDIS_SERVER` | `redis_server` | `string` | Redis server address |
+| `APP_REDIS_DATABASE` | `redis_database` | `int` | Redis Database (default: `0`) |
+| `APP_REDIS_PASSWORD` | `redis_password` | `string` | Redis password |
+| `APP_REDIS_SENTINEL_SERVERS` | `redis_sentinel_servers` | `[]string` | Redis Sentinel Server Addresses |
+| `APP_REDIS_SENTINEL_MASTER` | `redis_sentinel_master` | `string` | Redis Sentinel Master Instance Name |
+| `APP_REDIS_CONNECT_TIMEOUT` | `redis_connect_timeout` | `int` | Redis Connection Timeout in seconds |
+| `APP_REDIS_HOSTNAME_VERIFY` | `redis_hostname_verify` | `bool` | Skip hostname verification for TLS |
+| `APP_REDIS_KEEPALIVE` | `redis_keepalive` | `int` | TCP Keepalive Interval in seconds (Default: `300`) |
+| `APP_REDIS_MAX_ACTIVE` | `redis_max_active` | `int` | Max Active Connections |
+| `APP_REDIS_READ_TIMEOUT` | `redis_read_timeout` | `int` | Read timeout in seconds |
+| `APP_REDIS_WRITE_TIMEOUT` | `redis_write_timeout` | `int` | Write timeout in seconds |
+| `APP_CASSANDRA_HOSTS` | `cassandra_hosts` | `[]string` | Cassandra node addresses |
+| `APP_CASSANDRA_PORT` | `cassandra_port` | `int` | Cassandra node port |
+| `APP_CASSANDRA_KEYSPACE` | `cassandra_keyspace` | `string` | Cassandra Keyspace name |
+| `APP_CASSANDRA_CONSISTENCY` | `cassandra_consistency` | `string` | Desired Consistency (Default: `Quorum`)|
+| `APP_CASSANDRA_REPL_STRATEGY` | `cassandra_repl_strategy` | `string` | Replication Strategy for Cluster (Default: `SimpleStrategy`)|
+| `APP_CASSANDRA_REPLICAS` | `cassandra_replicas` | `int` | Default number of replicas for data (Default: `1`) |
+| `APP_CASSANDRA_USER` | `cassandra_user` | `string` | Username to authenticate with |
+| `APP_CASSANDRA_PASSWORD` | `cassandra_password` | `string` | Password to authenticate with |
+| `APP_CASSANDRA_HOSTNAME_VERIFY` | `cassandra_hostname_verify` | `bool` | Enable/Disable hostname verification for TLS |
 
 ## Consul Format
 
-When using Consul the `consul_keys_prefix` should be the path to a key with a JSON string as the value. For example, a key of `tarmac/config` will have a value of `{"from_consul":true}`.
+When using Consul the `consul_keys_prefix` should be the path to a key with a JSON `string` as the value. For example, a key of `tarmac/config` will have a value of `{"from_consul":true}`.
 
 ![](../.gitbook/assets/consul-example.png)
 

--- a/docs/running-tarmac/kvstore.md
+++ b/docs/running-tarmac/kvstore.md
@@ -1,0 +1,21 @@
+-----
+description: Selecting a KV Store
+-----
+
+# Key:Value Datastore Setup
+
+Tarmac has support for multiple Key:Value datastore storage systems. These datastores can change with basic 
+configuration options within Tarmac. As a WASM Function developer, you do not need to know the underlying datastore 
+when writing the function. Callbacks for accessing the Key:Value datastore are generic across all supported datastores.
+
+To start using a Key:Value datastore, set the `enable_kvstore` configuration to `true` and specify which supported 
+platform to use with the `kvstore_type` variable.
+
+The below table outlines the different available options.
+
+| Datastore | Type option | Description | Useful for |
+| --------  | ----------- | ----------- | ---------- |
+| Redis | `redis` | Redis including Sentinel and Enterprise capabilities | Strong Consistency, Fast Reads and Writes, Non-Persistent storage  |
+| Cassandra | `cassandra` | Cassandra including TLS connectivity | Eventual Consistency, Persistent Storage, Large sets of data |
+
+For more detailed configuration options, check out the [Configuration](configuration.md) documentation.

--- a/docs/running-tarmac/logging.md
+++ b/docs/running-tarmac/logging.md
@@ -1,0 +1,15 @@
+---
+description: Logging options of Tarmac
+---
+
+# Controlling Log Levels
+
+Administrators can control Tarmac's logging dynamically while using a distributed configuration service such as Consul. 
+As a WASM Function developer, you can select which logging level you wish your log callbacks to use. 
+
+As an Administrator, you can choose to enable or disable dynamically certain log levels such as Debug or Trace. To do 
+this, modify the `debug` and `trace` configuration options within Consul. 
+
+It is also possible to disable all logging by changing the `disable_logging` configuration option to `true`.
+
+For more information on connecting Tarmac with Consul, consult our [Configuration](configuration.md) documentation.

--- a/go.sum
+++ b/go.sum
@@ -34,9 +34,11 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c h1:+0HFd5KSZ/mm3JmhmrDukiId5iR6w4+BdFtfSy4yWIc=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -67,6 +69,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gocql/gocql v0.0.0-20200324094621-6d895e38b0a5 h1:LbX3qY8XXiD8kUJLvEsm3Hm2tjG3gQxThdmv9tW3cyI=
 github.com/gocql/gocql v0.0.0-20200324094621-6d895e38b0a5/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
@@ -82,6 +85,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
@@ -108,6 +112,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0 h1:bM6ZAFZmc/wPFaRDi0d5L7hGEZEx/2u+Tmr2evNHDiI=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0 h1:BNQPM9ytxj6jbjjdRPioQ94T6YXriSopn0i8COv6SRA=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
@@ -397,6 +402,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=


### PR DESCRIPTION
This pull request adds Cassandra support on top of the current Redis support that is already added. In addition, it paves the way for more databases to be supported as our dependency adds them. It also includes documentation around configuring KV Stores and the various options available for the ones we currently have.