### PR TITLE
Updating README for kv-counter

### DIFF
--- a/example/kv_counter/README.md
+++ b/example/kv_counter/README.md
@@ -3,8 +3,22 @@
 This project is an example of building a WASM-based microservice using Tarmac. This service is a KV Counter
 service that can be run both as an HTTP function or a scheduled task.
 
+To fetch the current value of the Counter, call the service with a GET request.
+
 ```console
+$ curl http://localhost
+6
 ```
+
+To increment the Counter, send a POST request with no payload.
+
+```console
+$ curl -X POST http://localhost
+7
+```
+
+In addition to the HTTP handlers, this WASM function runs as a scheduled task. Every 30 seconds, the Counter 
+will be incremented by one.
 
 Tarmac is a framework for building distributed services in any language. Like many other distributed 
 service/microservice frameworks, Tarmac abstracts the complexities of building distributed systems, eliminating the 


### PR DESCRIPTION
This updates the README for the KV Counter example to show the different ways to call the counter. It also highlights that the WASM function is set up as a scheduled task.