### PR TITLE
Adding System Metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 tests:
 	@echo "Launching Tests in Docker Compose"
 	docker-compose -f dev-compose.yml up -d cassandra-primary cassandra
-	sleep 15
+	sleep 30
 	docker-compose -f dev-compose.yml up --build tests
 
 clean:

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -137,6 +137,16 @@ func TestRunningServer(t *testing.T) {
 		}
 	})
 
+	t.Run("Check Metrics HTTP Handler", func(t *testing.T) {
+		r, err := http.Get("http://localhost:9000/metrics")
+		if err != nil {
+			t.Errorf("Unexpected error when requesting metrics status - %s", err)
+		}
+		if r.StatusCode != 200 {
+			t.Errorf("Unexpected http status code when checking metrics - %d", r.StatusCode)
+		}
+	})
+
 }
 
 func TestPProfServerEnabled(t *testing.T) {

--- a/app/kvstore.go
+++ b/app/kvstore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/madflojo/tarmac"
 	"github.com/pquerna/ffjson/ffjson"
+	"time"
 )
 
 // kvStore provides access to Host Callbacks that interact with the key:value datastores within Tarmac. The callbacks
@@ -16,6 +17,7 @@ type kvStore struct{}
 // base64 encoding of data are all handled via this function. Note, this function expects the KVStoreGetRequest
 // JSON type as input and will return a KVStoreGetResponse JSON.
 func (k *kvStore) Get(b []byte) ([]byte, error) {
+	now := time.Now()
 	// Start Response Message assuming everything is good
 	r := tarmac.KVStoreGetResponse{}
 	r.Status.Code = 200
@@ -46,12 +48,15 @@ func (k *kvStore) Get(b []byte) ([]byte, error) {
 	rsp, err := ffjson.Marshal(r)
 	if err != nil {
 		log.Errorf("Unable to marshal kvstore:get response - %s", err)
+		stats.kvstore.WithLabelValues("get").Observe(time.Since(now).Seconds())
 		return []byte(""), fmt.Errorf("unable to marshal kvstore:get response")
 	}
 
 	if r.Status.Code == 200 {
+		stats.kvstore.WithLabelValues("get").Observe(time.Since(now).Seconds())
 		return rsp, nil
 	}
+	stats.kvstore.WithLabelValues("get").Observe(time.Since(now).Seconds())
 	return rsp, fmt.Errorf("%s", r.Status.Status)
 }
 
@@ -59,6 +64,7 @@ func (k *kvStore) Get(b []byte) ([]byte, error) {
 // handling, and base64 decoding of data are all handled via this function. Note, this function expects the
 // KVStoreSetRequest JSON type as input and will return a KVStoreSetResponse JSON.
 func (k *kvStore) Set(b []byte) ([]byte, error) {
+	now := time.Now()
 	// Start Response Message assuming everything is good
 	r := tarmac.KVStoreSetResponse{}
 	r.Status.Code = 200
@@ -92,12 +98,15 @@ func (k *kvStore) Set(b []byte) ([]byte, error) {
 	rsp, err := ffjson.Marshal(r)
 	if err != nil {
 		log.Errorf("Unable to marshal kvstore:set response - %s", err)
+		stats.kvstore.WithLabelValues("set").Observe(time.Since(now).Seconds())
 		return []byte(""), fmt.Errorf("unable to marshal kvstore:set response")
 	}
 
 	if r.Status.Code == 200 {
+		stats.kvstore.WithLabelValues("set").Observe(time.Since(now).Seconds())
 		return rsp, nil
 	}
+	stats.kvstore.WithLabelValues("set").Observe(time.Since(now).Seconds())
 	return rsp, fmt.Errorf("%s", r.Status.Status)
 }
 
@@ -105,6 +114,7 @@ func (k *kvStore) Set(b []byte) ([]byte, error) {
 // JSON. Logging and error handling are all handled via this callback function. Note, this function expects the
 // KVStoreDeleteRequest JSON type as input and will return a KVStoreDeleteResponse JSON.
 func (k *kvStore) Delete(b []byte) ([]byte, error) {
+	now := time.Now()
 	// Start Response Message assuming everything is good
 	r := tarmac.KVStoreDeleteResponse{}
 	r.Status.Code = 200
@@ -131,18 +141,22 @@ func (k *kvStore) Delete(b []byte) ([]byte, error) {
 	rsp, err := ffjson.Marshal(r)
 	if err != nil {
 		log.Errorf("Unable to marshal kvstore:delete response - %s", err)
+		stats.kvstore.WithLabelValues("delete").Observe(time.Since(now).Seconds())
 		return []byte(""), fmt.Errorf("unable to marshal kvstore:delete response")
 	}
 
 	if r.Status.Code == 200 {
+		stats.kvstore.WithLabelValues("delete").Observe(time.Since(now).Seconds())
 		return rsp, nil
 	}
+	stats.kvstore.WithLabelValues("delete").Observe(time.Since(now).Seconds())
 	return rsp, fmt.Errorf("%s", r.Status.Status)
 }
 
 // Keys will return a list of all keys stored within the key:value datastore. Logging and error handling are
 // all handled via this callback function. Note, this function will return a KVStoreKeysResponse JSON.
 func (k *kvStore) Keys(b []byte) ([]byte, error) {
+	now := time.Now()
 	// Start Response Message assuming everything is good
 	r := tarmac.KVStoreKeysResponse{}
 	r.Status.Code = 200
@@ -160,11 +174,14 @@ func (k *kvStore) Keys(b []byte) ([]byte, error) {
 	rsp, err := ffjson.Marshal(r)
 	if err != nil {
 		log.Errorf("Unable to marshal kvstore:delete response - %s", err)
+		stats.kvstore.WithLabelValues("keys").Observe(time.Since(now).Seconds())
 		return []byte(""), fmt.Errorf("unable to marshal kvstore:delete response")
 	}
 
 	if r.Status.Code == 200 {
+		stats.kvstore.WithLabelValues("keys").Observe(time.Since(now).Seconds())
 		return rsp, nil
 	}
+	stats.kvstore.WithLabelValues("keys").Observe(time.Since(now).Seconds())
 	return rsp, fmt.Errorf("%s", r.Status.Status)
 }

--- a/app/system_metrics.go
+++ b/app/system_metrics.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// metrics provides the capability to manage and hold system internal metrics.
+type metrics struct {
+	// tasks is a summary metric of user scheduled task executions.
+	tasks *prometheus.SummaryVec
+
+	// srv is a summary metric of the HTTP server request processing.
+	srv *prometheus.SummaryVec
+
+	// callbacks is a counter metric of the WASM callbacks guests make.
+	callbacks *prometheus.CounterVec
+
+	// wasm is a summary metric of the WASM guest module executions.
+	wasm *prometheus.SummaryVec
+
+	// kvstore is a summary metric of the KVStore callback executions.
+	kvstore *prometheus.SummaryVec
+}
+
+// newMetrics will return an initialized systems metrics instance.
+func newMetrics() *metrics {
+	m := &metrics{}
+
+	m.srv = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "http_server",
+		Help:       "Summary of HTTP Server requests",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	},
+		[]string{"path"},
+	)
+
+	m.tasks = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "scheduled_tasks",
+		Help:       "Summary of user defined scheduled task WASM function executions",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	},
+		[]string{"tasks"},
+	)
+
+	m.callbacks = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "server_callbacks",
+		Help: "Count of waPC callback function executions",
+	},
+		[]string{"callback"},
+	)
+
+	m.wasm = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "wasm_functions",
+		Help:       "Summary of wasm function executions",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	},
+		[]string{"route"},
+	)
+
+	m.kvstore = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "kvstore_callbacks",
+		Help:       "Summary of kvstore callback executions",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	},
+		[]string{"callback"},
+	)
+
+	return m
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 * [Configuration](running-tarmac/configuration.md)
 * [Key:Value Datastore](running-tarmac/kvstore.md)
 * [Logging](running-tarmac/logging.md)
+* [Monitoring](running-tarmac/metrics.md)
 * [Scheduled Tasks](running-tarmac/scheduled-tasks.md)
 * [Troubleshooting Performance](running-tarmac/profiling.md)
 

--- a/docs/running-tarmac/metrics.md
+++ b/docs/running-tarmac/metrics.md
@@ -1,0 +1,21 @@
+---
+description: Monitoring Tarmac with Prometheus Metrics
+---
+
+# Monitoring
+
+Tarmac exposes several metrics to facilitate monitoring services. Metrics are available via the `/metrics` end-point in the Prometheus format.
+
+These metrics include internal Tarmac system metrics such as the number of goroutines, memory utilization, and WASM function-specific metrics such as counters for Callbacks and WASM function execution time.
+
+Some valuable metrics to monitor are in the below table.
+
+| Metric Name | Metric Type | Description |
+| ----------- | ----------- | ----------- |
+| `http_server` | Summary | Summary of HTTP Server requests |
+| `kvstore_callbacks` | Summary | Summary of kvstore callback executions |
+| `scheduled_tasks` | Summary | Summary of user defined scheduled task WASM function executions |
+| `server_callbacks` | Counter | waPC callback function executions |
+| `wasm_functions` | Summary | Summary of wasm function executions |
+
+These metrics do not need to be enabled and are "on by default".

--- a/docs/running-tarmac/profiling.md
+++ b/docs/running-tarmac/profiling.md
@@ -8,7 +8,7 @@ Troubleshooting Performance Issues or Memory leaks within running services can b
 
 PProf is a Go tool for capturing and visualizing profiling data. Tarmac uses the `net/http/pprof` package to make PProf available via HTTP end-points.
 
-By default, all PProf end-points are disabled, preventing unauthorized use of PProf (which itself can affect performance). To enable PProf, set the Configuration value of `enable-pprof` to `true`. Using a distributed configuration service such as Consul, users can change this value live without restarting the application instance.
+By default, all PProf end-points are disabled, preventing unauthorized use of PProf (which itself can affect performance). To enable PProf, set the Configuration value of `enable_pprof` to `true`. Using a distributed configuration service such as Consul, users can change this value live without restarting the application instance.
 
 Follow the [Configuration guide](configuration.md) for more details on configuring Tarmac.
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/madflojo/tasks v1.0.0
 	github.com/madflojo/testcerts v1.0.0
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7
+	github.com/prometheus/client_golang v0.9.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.7.1
 	github.com/wapc/wapc-go v0.2.1


### PR DESCRIPTION
This pull request adds system-level metrics to Tarmac. This included the standard items such as goroutine count, GC duration, memstats as well as custom ones such as WASM execution time, Scheduled Task execution times, Callback Counters, etc.