### PR TITLE
Fixing WASI Module error

### DIFF
--- a/example/echo/go/go.mod
+++ b/example/echo/go/go.mod
@@ -2,4 +2,4 @@ module github.com/madflojo/tarmac/example/echo/go
 
 go 1.16
 
-require github.com/wapc/wapc-guest-tinygo v0.3.0
+require github.com/wapc/wapc-guest-tinygo v0.3.1

--- a/example/echo/go/go.sum
+++ b/example/echo/go/go.sum
@@ -1,2 +1,2 @@
-github.com/wapc/wapc-guest-tinygo v0.3.0 h1:nBbzqjntOSA4jXamwhfCDQhlOtfneGNPxRG0dI5MZVE=
-github.com/wapc/wapc-guest-tinygo v0.3.0/go.mod h1:Jssn+ovE+Y2oueUgVeLyGZf2ipUPngVnWTNPM8zmhn0=
+github.com/wapc/wapc-guest-tinygo v0.3.1 h1:ecmT4W+ynsNvRvLolPw2rQRafCAoLMh7L/u6ZxVSWXU=
+github.com/wapc/wapc-guest-tinygo v0.3.1/go.mod h1:Jssn+ovE+Y2oueUgVeLyGZf2ipUPngVnWTNPM8zmhn0=

--- a/example/tac/go/go.mod
+++ b/example/tac/go/go.mod
@@ -2,4 +2,4 @@ module github.com/madflojo/tarmac/example/hello/go
 
 go 1.16
 
-require github.com/wapc/wapc-guest-tinygo v0.3.0
+require github.com/wapc/wapc-guest-tinygo v0.3.1

--- a/example/tac/go/go.sum
+++ b/example/tac/go/go.sum
@@ -1,2 +1,2 @@
-github.com/wapc/wapc-guest-tinygo v0.3.0 h1:nBbzqjntOSA4jXamwhfCDQhlOtfneGNPxRG0dI5MZVE=
-github.com/wapc/wapc-guest-tinygo v0.3.0/go.mod h1:Jssn+ovE+Y2oueUgVeLyGZf2ipUPngVnWTNPM8zmhn0=
+github.com/wapc/wapc-guest-tinygo v0.3.1 h1:ecmT4W+ynsNvRvLolPw2rQRafCAoLMh7L/u6ZxVSWXU=
+github.com/wapc/wapc-guest-tinygo v0.3.1/go.mod h1:Jssn+ovE+Y2oueUgVeLyGZf2ipUPngVnWTNPM8zmhn0=


### PR DESCRIPTION
When looking more into the error and reading some of the maintainers for wapc comments on previous Pull Requests, I came across the release notes for this: https://github.com/wapc/wapc-guest-tinygo/releases/tag/v0.3.1

There were some changes in TinyGo v0.19 that the older version of wapc-guest-tinygo didn't work well with. But with the new version `v0.3.1`, everything seems to be working fine.