### PR TITLE
Updating function handlers for multi-tenancy functions

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -110,7 +110,7 @@ func (s *server) WASMHandler(w http.ResponseWriter, r *http.Request, ps httprout
 	}
 
 	// Execute WASM Module
-	rsp, err := runWASM("default", r.Method, payload)
+	rsp, err := runWASM("default", "handler", payload)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"method":         r.Method,

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -67,7 +67,7 @@ func TestHandlers(t *testing.T) {
 			t.Fatalf("Unexpected error when making HTTP request - %s", err)
 		}
 		defer r.Body.Close()
-		if r.StatusCode != 500 {
+		if r.StatusCode != 200 {
 			t.Errorf("Unexpected http status code when making request %d", r.StatusCode)
 		}
 	})
@@ -90,16 +90,6 @@ func TestHandlers(t *testing.T) {
 		}
 	})
 
-	t.Run("Invalid Head Request", func(t *testing.T) {
-		r, err := http.Head("http://localhost:9001/")
-		if err != nil {
-			t.Fatalf("Unexpected error when making HTTP request - %s", err)
-		}
-		defer r.Body.Close()
-		if r.StatusCode < 500 {
-			t.Errorf("Unexpected http status code when making request %d", r.StatusCode)
-		}
-	})
 }
 
 func TestWASMRunner(t *testing.T) {
@@ -134,7 +124,7 @@ func TestWASMRunner(t *testing.T) {
 		err:     true,
 		pass:    false,
 		module:  "notfound",
-		handler: "GET",
+		handler: "handler",
 		request: []byte(""),
 	})
 
@@ -143,7 +133,7 @@ func TestWASMRunner(t *testing.T) {
 		err:     false,
 		pass:    false,
 		module:  "default",
-		handler: "POST",
+		handler: "handler",
 		request: []byte("ohmy"),
 	})
 
@@ -152,7 +142,7 @@ func TestWASMRunner(t *testing.T) {
 		err:     false,
 		pass:    true,
 		module:  "default",
-		handler: "POST",
+		handler: "handler",
 		request: []byte("howdie"),
 	})
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ![](tarmac-logo.png)
 
-Framework for building distributed services with WebAssembly
+Tarmac: Building Serverless Applications with WebAssembly, Simplified
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/madflojo/tarmac)](https://pkg.go.dev/github.com/madflojo/tarmac)
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://tarmac.gitbook.io/tarmac/)
@@ -10,10 +10,13 @@ Framework for building distributed services with WebAssembly
 [![Go Report Card](https://goreportcard.com/badge/github.com/madflojo/tarmac)](https://goreportcard.com/report/github.com/madflojo/tarmac)
 [![Coverage Status](https://coveralls.io/repos/github/madflojo/tarmac/badge.svg?branch=master)](https://coveralls.io/github/madflojo/tarmac?branch=master)
 
+Tarmac is an open-source platform for building serverless applications using WebAssembly and WASI. Unlike traditional serverless platforms, Tarmac eliminates cold start times by loading functions at startup, providing near-instantaneous response times for function invocations.
 
-Tarmac is a unique framework designed for the next generation of distributed systems. At its core, like many other microservice frameworks, Tarmac is focused on abstracting the complexities of building cloud-native services allowing users to focus more on business logic and less on boilerplate code.
+Tarmac also offers a unique approach to interacting with external systems, using host callbacks to provide access to key-value stores, databases, and HTTP APIs. This makes it easy to build complex, distributed applications that can scale to meet demand.
 
-What makes Tarmac unique is that, unlike most microservice frameworks, Tarmac is language agnostic. Using WebAssembly \(WASM\), Tarmac users can write their business logic in many different languages such as Rust, Go, Javascript, or even Swift; and run it all using the same core framework.
+By leveraging the security and portability of WebAssembly and WASI, Tarmac provides a lightweight and secure runtime environment for serverless functions. This enables developers to build and deploy applications quickly and easily, without worrying about the infrastructure or server maintenance.
+
+Overall, Tarmac offers a new and innovative approach to building serverless applications, with unique features and benefits that set it apart from traditional serverless platforms.
 
 ## Tarmac vs. Serverless Functions
 
@@ -21,17 +24,15 @@ Tarmac shares many traits with Serverless Functions and Functions as a Service \
 
 But Tarmac takes Serverless Functions further. In general, FaaS platforms provide a simple runtime for user code. If a function requires any dependency \(i.e., a Database\), the developer-provided function code must maintain the database connectivity and query calls.
 
-Using the power of WebAssembly, Tarmac not only provides functions a secure sandboxed runtime environment, but it also provides abstractions that developers can use to interact with platform capabilities such as Databases, Caching, Metrics, and even Dynamic Configuration.
+Using the power of WebAssembly, Tarmac not only provides functions a secure sandboxed runtime environment, but it also provides abstractions that developers can use to interact with platform capabilities such as Databases, Caching, and even Metrics.
 
 In many ways, Tarmac is more akin to a microservices framework with the developer experience of a FaaS platform.
 
 ## Quick Start
 
-At the moment, Tramac is executing WASM functions by executing a defined set of function signatures. When Tarmac receives an HTTP GET request, it will call the function's registered under the `GET` signature.
+To start executing WASM functions with Tarmac, we must define a single "Handler" function. This function will accept a byte slice as its input. The contents of this byte slice will be the HTTP payload sent to the service.
 
-As part of the WASM Function, users must register their handlers using the pre-defined function signatures.
-
-To understand this better, look at one of our simple examples \(found in [example/](https://github.com/madflojo/tarmac/blob/main/example/tac/README.md)\).
+To see more examples look at one of our simple examples \(found in [example/](https://github.com/madflojo/tarmac/blob/main/example/tac/README.md)\).
 
 ```go
 // Tac is a small, simple Go program that is an example WASM module for Tarmac. This program will accept a Tarmac
@@ -44,24 +45,10 @@ import (
 )
 
 func main() {
-        // Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers under the
-        // appropriate method as shown below.
+        // Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers
         wapc.RegisterFunctions(wapc.Functions{
-                // Register a GET request handler
-                "GET": NoHandler,
-                // Register a POST request handler
-                "POST": Handler,
-                // Register a PUT request handler
-                "PUT": Handler,
-                // Register a DELETE request handler
-                "DELETE": NoHandler,
+                "handler": Handler,
         })
-}
-
-// NoHandler is a custom Tarmac Handler function that will return an error that denies
-// the client request.
-func NoHandler(payload []byte) ([]byte, error) {
-        return []byte(""), fmt.Errorf("Not Implemented")
 }
 
 // Handler is the custom Tarmac Handler function that will receive a payload and

--- a/docs/wasm-functions/go.md
+++ b/docs/wasm-functions/go.md
@@ -25,20 +25,17 @@ import (
 )
 ```
 
-Once the waPC package is imported, we will create a `main()` function; this function will be our primary entry point for Tarmac execution. Within this function, we will register other handler functions for Tarmac to execute using the `wapc.RegisterFunctions` function.
+Once the waPC package is imported, we will create a `main()` function; this function will be our primary entry point for Tarmac execution. Within this function, we will register our handler function for Tarmac to execute using the `wapc.RegisterFunctions` function.
 
 ```go
 func main() {
 	wapc.RegisterFunctions(wapc.Functions{
-		// Register a POST request handler
-		"POST": Handler,
-		// Register a PUT request handler
-		"PUT": Handler,
+		"handler": Handler,
 	})
 }
 ```
 
-In the example above, we have registered the `Handler` function under two Tarmac routes; `POST` and `PUT`. When Tarmac receives an HTTP POST request for this WASM Function, it will execute the handler function as defined. If we wanted this function also to be used for HTTP GET requests, we could add another line registering it under `GET`.
+In the example above, we have registered the `Handler` function. When Tarmac receives an HTTP POST request for this WASM Function, it will execute the handler function as defined.
 
 With our handler function registered, we must create a basic function.
 
@@ -110,21 +107,8 @@ func main() {
         // Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers under the
         // appropriate method as shown below.
         wapc.RegisterFunctions(wapc.Functions{
-                // Register a GET request handler
-                "GET": NoHandler,
-                // Register a POST request handler
-                "POST": Handler,
-                // Register a PUT request handler
-                "PUT": Handler,
-                // Register a DELETE request handler
-                "DELETE": NoHandler,
+                "handler": Handler,
         })
-}
-
-// NoHandler is a custom Tarmac Handler function that will return an error that denies
-// the client request.
-func NoHandler(payload []byte) ([]byte, error) {
-        return []byte(""), fmt.Errorf("Not Implemented")
 }
 
 // Handler is the custom Tarmac Handler function that will receive a payload and

--- a/docs/wasm-functions/rust.md
+++ b/docs/wasm-functions/rust.md
@@ -28,19 +28,16 @@ fn main() {}
 pub extern "C" fn wapc_init() {}
 ```
 
-Along with the waPC imports, you should also see a `wapc_init()` function created. This function is the primary entry point for Tarmac execution. We will register other handler functions for Tarmac to execute using the `register_function()` function within this function.
+Along with the waPC imports, you should also see a `wapc_init()` function created. This function is the primary entry point for Tarmac execution. We will register our handler function for Tarmac to execute using the `register_function()` function within this function.
 
 ```rust
 #[no_mangle]
 pub extern "C" fn wapc_init() {
-  // Add Handler for the POST request
-  register_function("POST", handler);
-  // Add Handler for the PUT request
-  register_function("PUT", handler);
+  register_function("handler", handler);
 }
 ```
 
-In the example above, we have registered the `handler()` function under two Tarmac routes; `POST` and `PUT`. When Tarmac receives an HTTP POST request for this WASM function, it will execute the handler function as defined. If we wanted this function to be used for HTTP GET requests, we could add another line registering it under `GET`.
+In the example above, we have registered the `handler()` function. When Tarmac receives an HTTP POST request for this WASM function, it will execute the handler function as defined.
 
 With our handler function now registered, we must create a basic version of this handler for Tarmac to call.
 
@@ -89,10 +86,7 @@ fn main() {}
 
 #[no_mangle]
 pub extern "C" fn wapc_init() {
-  // Add Handler for the POST request
-  register_function("POST", handler);
-  // Add Handler for the PUT request
-  register_function("PUT", handler);
+  register_function("handler", handler);
 }
 
 fn handler(msg: &[u8]) -> CallResult {

--- a/example/echo/go/Makefile
+++ b/example/echo/go/Makefile
@@ -2,7 +2,7 @@
 
 build:
 	mkdir -p functions
-	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.25.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.26.0 tinygo build -o /build/functions/tarmac.wasm -target wasi /build/main.go
 
 docker-compose:
 	docker compose up

--- a/example/echo/go/main.go
+++ b/example/echo/go/main.go
@@ -11,21 +11,9 @@ func main() {
 	// Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers under the
 	// appropriate method as shown below.
 	wapc.RegisterFunctions(wapc.Functions{
-		// Register a GET request handler
-		"GET": NoHandler,
-		// Register a POST request handler
-		"POST": Handler,
-		// Register a PUT request handler
-		"PUT": Handler,
-		// Register a DELETE request handler
-		"DELETE": NoHandler,
+		// Register request handler
+		"handler": Handler,
 	})
-}
-
-// NoHandler is a custom Tarmac Handler function that will return an error that denies
-// the client request.
-func NoHandler(payload []byte) ([]byte, error) {
-	return []byte(""), fmt.Errorf("Not Implemented")
 }
 
 // Handler is the custom Tarmac Handler function that will receive a payload and

--- a/example/echo/rust/src/main.rs
+++ b/example/echo/rust/src/main.rs
@@ -7,10 +7,8 @@ fn main() {}
 
 #[no_mangle]
 pub extern "C" fn wapc_init() {
-  // Add Handler for the POST request
-  register_function("POST", handler);
-  // Add Handler for the PUT request
-  register_function("PUT", handler);
+  // Register Handler for requests
+  register_function("handler", handler);
 }
 
 fn handler(msg: &[u8]) -> CallResult {

--- a/example/tac/go/main.go
+++ b/example/tac/go/main.go
@@ -8,24 +8,11 @@ import (
 )
 
 func main() {
-	// Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers under the
-	// appropriate method as shown below.
+	// Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers 
 	wapc.RegisterFunctions(wapc.Functions{
-		// Register a GET request handler
-		"GET": NoHandler,
-		// Register a POST request handler
-		"POST": Handler,
-		// Register a PUT request handler
-		"PUT": Handler,
-		// Register a DELETE request handler
-		"DELETE": NoHandler,
+		// Register request handler
+		"handler": Handler,
 	})
-}
-
-// NoHandler is a custom Tarmac Handler function that will return an error that denies
-// the client request.
-func NoHandler(payload []byte) ([]byte, error) {
-	return []byte(""), fmt.Errorf("Not Implemented")
 }
 
 // Handler is the custom Tarmac Handler function that will receive a payload and

--- a/pkg/wasm/wasm_test.go
+++ b/pkg/wasm/wasm_test.go
@@ -131,7 +131,7 @@ func TestWASMExecution(t *testing.T) {
 	}
 
 	go func() {
-		_, err = m.Run("POST", []byte(`hello`))
+		_, err = m.Run("handler", []byte(`hello`))
 		if err != nil {
 			t.Logf("Could not execute the wasm function - %s", err)
 		}

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -7,25 +7,15 @@ import (
 )
 
 func main() {
-	// Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers under the
-	// appropriate method as shown below.
+	// Tarmac uses waPC to facilitate WASM module execution. Modules must register their custom handlers 
 	wapc.RegisterFunctions(wapc.Functions{
-		// Register a GET request handler
-		"GET": NoHandler,
-		// Register a POST request handler
-		"POST": Handler,
-		// Register a PUT request handler
-		"PUT": Handler,
-		// Register a DELETE request handler
-		"DELETE": NoHandler,
+    "handler": Handler,
 	})
 }
 
-func NoHandler(payload []byte) ([]byte, error) {
-	return []byte(""), fmt.Errorf("Not Implemented")
-}
-
 func Handler(payload []byte) ([]byte, error) {
+  fmt.Printf("Output from WASM Modules goes here\n")
+
 	// Log the payload
 	_, err := wapc.HostCall("tarmac", "logger", "info", []byte(`Testdata Function Starting Execution`))
 	if err != nil {


### PR DESCRIPTION
This is likely to break people, but a necessary evil for moving to a multi-tenancy model where users can define different functions and register them under different routes.