### PR TITLE
Adding Function Calls to SDK

### DIFF
--- a/pkg/sdk/function/function.go
+++ b/pkg/sdk/function/function.go
@@ -1,0 +1,45 @@
+/*
+Package function is a client package for WASM functions running within a Tarmac server.
+
+This package provides user-friendly function to call other WASM functions.
+*/
+package function
+
+import "fmt"
+
+// Function provides a simple interface for Tarmac Functions to send messages via the standard function.
+type Function struct {
+	namespace string
+	hostCall  func(string, string, string, []byte) ([]byte, error)
+}
+
+// Config provides users with the ability to specify namespaces, function handlers and other key information required to execute the
+// function.
+type Config struct {
+	// Namespace controls the function namespace to use for host callbacks. The default value is "default" which is the global namespace.
+	// Users can provide an alternative namespace by specifying this field.
+	Namespace string
+
+	// HostCall is used internally for host callbacks. This is mainly here for testing.
+	HostCall func(string, string, string, []byte) ([]byte, error)
+}
+
+// New creates a new Function with the provided configuration.
+func New(cfg Config) (*Function, error) {
+	// Set default namespace
+	if cfg.Namespace == "" {
+		cfg.Namespace = "default"
+	}
+
+	// Verify HostCall is set
+	if cfg.HostCall == nil {
+		return &Function{}, fmt.Errorf("HostCall cannot be nil")
+	}
+
+	return &Function{namespace: cfg.Namespace, hostCall: cfg.HostCall}, nil
+}
+
+// Call will call other functions registered via Tarmac routes.
+func (f *Function) Call(name string, input []byte) ([]byte, error) {
+	return f.hostCall(f.namespace, "function", name, input)
+}

--- a/pkg/sdk/function/function_test.go
+++ b/pkg/sdk/function/function_test.go
@@ -1,0 +1,54 @@
+package function
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFunction(t *testing.T) {
+	// Initialize function with mock hostCall
+	function, err := New(Config{Namespace: "default", HostCall: func(namespace string, capability string, function string, input []byte) ([]byte, error) {
+		if namespace != "default" || capability != "function" || function != "test-func" {
+			t.Errorf("hostcall signature invalid %s, %s, %s", namespace, capability, function)
+		}
+		if len(input) != len([]byte("Hey hey hey")) {
+			t.Errorf("unexpected input vs. payload")
+		}
+		return []byte("Success"), nil
+	}})
+	if err != nil {
+		t.Errorf("unexpected error initializing function - %s", err)
+	}
+
+	// Call function method
+	d, err := function.Call("test-func", []byte("Hey hey hey"))
+	if err != nil {
+		t.Errorf("unexpected error returned from function - %s", err)
+	}
+
+	if len(d) != len([]byte("Success")) {
+		t.Errorf("unexpected output from function to function call")
+	}
+}
+
+func TestFunctionFail(t *testing.T) {
+	// Initialize function with mock hostCall
+	function, err := New(Config{Namespace: "default", HostCall: func(namespace string, capability string, function string, input []byte) ([]byte, error) {
+		if namespace != "default" || capability != "function" || function != "test-func" {
+			t.Errorf("hostcall signature invalid %s, %s, %s", namespace, capability, function)
+		}
+		if len(input) != len([]byte("Hey hey hey")) {
+			t.Errorf("unexpected input vs. payload")
+		}
+		return []byte(""), fmt.Errorf("This is an error")
+	}})
+	if err != nil {
+		t.Errorf("unexpected error initializing function - %s", err)
+	}
+
+	// Call function method
+	_, err = function.Call("test-func", []byte("Hey hey hey"))
+	if err == nil {
+		t.Errorf("unexpected success returned from function")
+	}
+}

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -30,6 +30,7 @@ import (
 	"github.com/madflojo/tarmac/pkg/sdk/logger"
 	"github.com/madflojo/tarmac/pkg/sdk/metrics"
 	"github.com/madflojo/tarmac/pkg/sdk/sql"
+	"github.com/madflojo/tarmac/pkg/sdk/function"
 	wapc "github.com/wapc/wapc-guest-tinygo"
 )
 
@@ -51,6 +52,9 @@ type Tarmac struct {
 
 	// SQL provides an interface to the underlying SQL datastores within Tarmac.
 	SQL *sql.SQL
+
+	// Function provides an interface to call other WASM functions registered within Tarmac.
+	Function *function.Function
 
 	// Logger provides an interface to the Tarmac structured logger, enabling users to create log messages from functions.
 	Logger *logger.Logger
@@ -124,6 +128,12 @@ func New(cfg Config) (*Tarmac, error) {
 	t.SQL, err = sql.New(sql.Config{Namespace: cfg.Namespace, HostCall: cfg.hostCall})
 	if err != nil {
 		return t, fmt.Errorf("error while initializing SQL - %s", err)
+	}
+
+	// Initialize a Function instance
+	t.Function, err = function.New(sql.Config{Namespace: cfg.Namespace, HostCall: cfg.hostCall})
+	if err != nil {
+		return t, fmt.Errorf("error while initializing Function - %s", err)
 	}
 
 	return t, nil


### PR DESCRIPTION
This adds to the SDK function to function callbacks. The code is yet to be implemented in Tarmac but will follow shortly.