### PR TITLE
Adding function to function calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build-testdata:
 	$(MAKE) -C testdata/kv build
 	$(MAKE) -C testdata/sql build
 	$(MAKE) -C testdata/logger build
+	$(MAKE) -C testdata/function build
 
 tests: build
 	@echo "Launching Tests in Docker Compose"

--- a/app/app.go
+++ b/app/app.go
@@ -446,6 +446,12 @@ func Run(c *viper.Viper) error {
 					defer scheduler.Del(id)
 				}
 
+				if r.Type == "function" {
+					log.Infof("Registering Function to Function callback for %s", r.Function)
+					router.RegisterCallback("function", r.Function, func(b []byte) ([]byte, error) {
+						return runWASM(r.Function, "handler", b)
+					})
+				}
 			}
 		}
 

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -152,6 +152,17 @@ func TestFullService(t *testing.T) {
 			t.Errorf("Unexpected http status code when making request %d", r.StatusCode)
 		}
 	})
+
+	t.Run("Do a Get on /func", func(t *testing.T) {
+		r, err := http.Get("http://localhost:9001/func")
+		if err != nil {
+			t.Fatalf("Unexpected error when making HTTP request - %s", err)
+		}
+		defer r.Body.Close()
+		if r.StatusCode != 200 {
+			t.Errorf("Unexpected http status code when making request %d", r.StatusCode)
+		}
+	})
 }
 
 func TestWASMRunner(t *testing.T) {

--- a/docs/callback-functions/functions.md
+++ b/docs/callback-functions/functions.md
@@ -1,0 +1,19 @@
+---
+description: Function to Function calls
+---
+
+# Functions
+
+The Functions capability allows WASM functions to call other WASM functions. Unlike other callback capabilities, functions must register within the routes configuration within the `tarmac.json` configuration file.
+
+## Function
+
+```golang
+_, err := wapc.HostCall("tarmac", "function", "function-name", []byte("Input to Function"))
+```
+
+### Interface Details
+
+| Namespace | Capability | Function | Input | Output |
+| --------- | ---------- | -------- | ----- | ------ |
+| `tarmac` | `function` | Function Name | Input Data | Function Output Data |

--- a/docs/wasm-functions/go.md
+++ b/docs/wasm-functions/go.md
@@ -154,7 +154,7 @@ We are now ready to run our WASM function via Tarmac. To make this process easie
 ```text
 $ docker run -p 8080:8080 \
   -e "APP_ENABLE_TLS=false" -e "APP_LISTEN_ADDR=0.0.0.0:8080" \
-  -v ./functions:/functions madflojo/tarmac
+  -v `pwd`./functions:/functions madflojo/tarmac
 ```
 
 In the above command, we are passing two environment variables to the container using the `-e` flag. These environment variables will tell Tarmac to use HTTP rather than HTTPS, which is the default. For additional configuration options, check out the [Configuration](../running-tarmac/configuration.md) documentation.

--- a/docs/wasm-functions/multi-function-services.md
+++ b/docs/wasm-functions/multi-function-services.md
@@ -116,3 +116,20 @@ Here is an example of a route object that defines a scheduled task that executes
 ```
 
 You can define multiple scheduled tasks in the routes array.
+
+##### Functions
+
+Tarmac supports the ability for Functions to call other Functions using the Function to Function route. 
+
+You can define a function route by adding a route object with the following properties to the route array.
+
+- `function` (required): The function to call when executed.
+
+Here is an example of a route object that defines the "function1" function.
+
+```json
+{
+  "type": "function",
+  "function": "function1"
+}
+```

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -25,12 +25,12 @@ package sdk
 
 import (
 	"fmt"
+	"github.com/madflojo/tarmac/pkg/sdk/function"
 	"github.com/madflojo/tarmac/pkg/sdk/http"
 	"github.com/madflojo/tarmac/pkg/sdk/kvstore"
 	"github.com/madflojo/tarmac/pkg/sdk/logger"
 	"github.com/madflojo/tarmac/pkg/sdk/metrics"
 	"github.com/madflojo/tarmac/pkg/sdk/sql"
-	"github.com/madflojo/tarmac/pkg/sdk/function"
 	wapc "github.com/wapc/wapc-guest-tinygo"
 )
 

--- a/testdata/function/Makefile
+++ b/testdata/function/Makefile
@@ -1,0 +1,10 @@
+## Makefile for Go example for Tarmac WASM functions
+
+build:
+	## Run TinyGo build via Docker because its easier
+	docker run -v `pwd`/:/build -w /build tinygo/tinygo:0.25.0 tinygo build -o /build/tarmac.wasm -target wasi /build/main.go
+
+docker-compose:
+	docker compose up
+
+run: build docker-compose

--- a/testdata/function/docker-compose.yml
+++ b/testdata/function/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  tarmac-example:
+    image: madflojo/tarmac
+    ports:
+      - 80:8080
+    environment:
+      - "APP_ENABLE_TLS=false"
+      - "APP_LISTEN_ADDR=0.0.0.0:8080"
+      - "APP_DEBUG=true"
+    volumes:
+      - "./:/functions"

--- a/testdata/function/go.mod
+++ b/testdata/function/go.mod
@@ -2,7 +2,7 @@ module github.com/madflojo/tarmac/testdata/function
 
 go 1.20
 
-require github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321144106-5660ed0833f7
+require github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321151604-26290eb26344
 
 require (
 	github.com/valyala/fastjson v1.6.4 // indirect

--- a/testdata/function/go.mod
+++ b/testdata/function/go.mod
@@ -1,0 +1,10 @@
+module github.com/madflojo/tarmac/testdata/function
+
+go 1.20
+
+require github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321144106-5660ed0833f7
+
+require (
+	github.com/valyala/fastjson v1.6.4 // indirect
+	github.com/wapc/wapc-guest-tinygo v0.3.3 // indirect
+)

--- a/testdata/function/go.sum
+++ b/testdata/function/go.sum
@@ -1,0 +1,9 @@
+github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321014433-e6f0bd5372cb h1:tPLWm29IF4M5RBuMvJHQ+aoiDbpUc9Axa5boXWFVDcQ=
+github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321014433-e6f0bd5372cb/go.mod h1:mUxc4sw0vpBVcJFyCXpSqeWr6MwpvnZS33bgqOCI1N8=
+github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321144106-5660ed0833f7 h1:tmyYxD0OCK7e5/bFlv+tUfEYkJiPVddVv9gRyK335bc=
+github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321144106-5660ed0833f7/go.mod h1:mUxc4sw0vpBVcJFyCXpSqeWr6MwpvnZS33bgqOCI1N8=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
+github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
+github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/testdata/function/go.sum
+++ b/testdata/function/go.sum
@@ -1,7 +1,7 @@
-github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321014433-e6f0bd5372cb h1:tPLWm29IF4M5RBuMvJHQ+aoiDbpUc9Axa5boXWFVDcQ=
-github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321014433-e6f0bd5372cb/go.mod h1:mUxc4sw0vpBVcJFyCXpSqeWr6MwpvnZS33bgqOCI1N8=
 github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321144106-5660ed0833f7 h1:tmyYxD0OCK7e5/bFlv+tUfEYkJiPVddVv9gRyK335bc=
 github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321144106-5660ed0833f7/go.mod h1:mUxc4sw0vpBVcJFyCXpSqeWr6MwpvnZS33bgqOCI1N8=
+github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321151604-26290eb26344 h1:78AHg7YcWjopfaihgTCUQfCXBysp/GUIYM1d3BUWdZA=
+github.com/madflojo/tarmac/pkg/sdk v0.0.0-20230321151604-26290eb26344/go.mod h1:mUxc4sw0vpBVcJFyCXpSqeWr6MwpvnZS33bgqOCI1N8=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/testdata/function/main.go
+++ b/testdata/function/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/madflojo/tarmac/pkg/sdk"
 )
 

--- a/testdata/function/main.go
+++ b/testdata/function/main.go
@@ -1,0 +1,27 @@
+// This program is a test program used to facilitate unit testing with Tarmac.
+package main
+
+import (
+	"fmt"
+	"github.com/madflojo/tarmac/pkg/sdk"
+)
+
+var tarmac *sdk.Tarmac
+
+func main() {
+	var err error
+
+	// Initialize the Tarmac SDK
+	tarmac, err = sdk.New(sdk.Config{Namespace: "test-service", Handler: Handler})
+	if err != nil {
+		return
+	}
+}
+
+func Handler(payload []byte) ([]byte, error) {
+	// Call another function
+	tarmac.Function.Call("logger", payload)
+
+	// Return a happy message
+	return payload, nil
+}

--- a/testdata/tarmac.json
+++ b/testdata/tarmac.json
@@ -14,6 +14,9 @@
         },
         "sql": {
           "filepath": "/testdata/sql/tarmac.wasm"
+        },
+        "func": {
+          "filepath": "/testdata/function/tarmac.wasm"
         }
       },
       "routes": [
@@ -42,9 +45,19 @@
           "function": "sql"
         },
         {
+          "type": "http",
+          "path": "/func",
+          "methods": ["GET"],
+          "function": "func"
+        },
+        {
           "type": "scheduled_task",
           "frequency": 15,
           "function": "default"
+        },
+        {
+          "type": "function",
+          "function": "logger"
         }
       ]
     }


### PR DESCRIPTION
This PR will add function to function callback capabilities to Tarmac. This will let WASM functions call another WASM function with the hostcall returning the output of the called function.

Users must register functions in the routes in order to make them callable as it didn't make sense to make all functions callable by default to me.